### PR TITLE
Add access to the token endpoint

### DIFF
--- a/bond_api/bond.py
+++ b/bond_api/bond.py
@@ -37,6 +37,10 @@ class Bond:
         """Return the version of hub/bridge reported by API."""
         return await self.__get("/v2/sys/version")
 
+    async def token(self) -> dict:
+        """Return the token after power rest or proof of ownership event."""
+        return await self.__get("/v2/token")
+
     async def bridge(self) -> dict:
         """Return the name and location of the bridge."""
         return await self.__get("/v2/bridge")

--- a/tests/test_bond.py
+++ b/tests/test_bond.py
@@ -53,6 +53,18 @@ async def test_bridge(bond: Bond):
 
 
 @pytest.mark.asyncio
+async def test_token(bond: Bond):
+    """Tests token API."""
+    with aioresponses() as response:
+        response.get(
+            "http://test-host/v2/token",
+            payload={"locked": 0,"token": "8f514567acaf9869"}
+        )
+        actual = await bond.token()
+        assert actual == {"locked": 0,"token": "8f514567acaf9869"}
+
+
+@pytest.mark.asyncio
 async def test_devices(bond: Bond):
     """Tests API to get a list of device IDs."""
     with aioresponses() as response:


### PR DESCRIPTION
If the fan or bridge has the power reset, the token is accessible for
10 minutes before the endpoint is locked. We can allow home assistant
to setup the device without the user having to use the app to find
the token by resetting the power to it.