### PR TITLE
Retry the api call on disconnect

### DIFF
--- a/bond_api/bond.py
+++ b/bond_api/bond.py
@@ -3,7 +3,7 @@
 from typing import Any, Callable, List, Optional
 
 from aiohttp import ClientSession, ClientTimeout
-from aiohttp.client_exceptions import ServerDisconnectedError
+from aiohttp.client_exceptions import ServerDisconnectedError, ClientOSError
 
 from .action import Action
 
@@ -99,7 +99,7 @@ class Bond:
         else:
             try:
                 return await handler(self._session)
-            except ServerDisconnectedError:
+            except (ClientOSError, ServerDisconnectedError):
                 # bond has a short connection close time
                 # so we need to retry if we idled for a bit
                 return await handler(self._session)


### PR DESCRIPTION
Fixes
```
2022-01-23 21:35:46 ERROR (MainThread) [homeassistant.components.websocket_api.http.connection] [140002317754912] [Errno None] Can not write request body for http://192.168.106.38/v2/devices/1/actions/TurnOff
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/aiohttp/client_reqrep.py", line 583, in write_bytes
    await self.body.write(writer)
  File "/usr/local/lib/python3.9/site-packages/aiohttp/payload.py", line 247, in write
    await writer.write(self._value)
  File "/usr/local/lib/python3.9/site-packages/aiohttp/http_writer.py", line 116, in write
    self._write(chunk)
  File "/usr/local/lib/python3.9/site-packages/aiohttp/http_writer.py", line 76, in _write
    raise ConnectionResetError("Cannot write to closing transport")
ConnectionResetError: Cannot write to closing transport

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/websocket_api/commands.py", line 190, in handle_call_service
    await hass.services.async_call(
  File "/usr/src/homeassistant/homeassistant/core.py", line 1630, in async_call
    task.result()
  File "/usr/src/homeassistant/homeassistant/core.py", line 1667, in _execute_service
    await cast(Callable[[ServiceCall], Awaitable[None]], handler.job.target)(
  File "/usr/src/homeassistant/homeassistant/helpers/entity_component.py", line 204, in handle_service
    await self.hass.helpers.service.entity_service_call(
  File "/usr/src/homeassistant/homeassistant/helpers/service.py", line 668, in entity_service_call
    future.result()  # pop exception if have
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 898, in async_request_call
    await coro
  File "/usr/src/homeassistant/homeassistant/helpers/service.py", line 705, in _handle_entity_call
    await result
  File "/usr/src/homeassistant/homeassistant/components/bond/fan.py", line 215, in async_turn_off
    await self._hub.bond.action(self._device.device_id, Action.turn_off())
  File "/usr/local/lib/python3.9/site-packages/bond_api/bond.py", line 83, in action
    await self.__call(put)
  File "/usr/local/lib/python3.9/site-packages/bond_api/bond.py", line 101, in __call
    return await handler(self._session)
  File "/usr/local/lib/python3.9/site-packages/bond_api/bond.py", line 76, in put
    async with session.put(
  File "/usr/local/lib/python3.9/site-packages/aiohttp/client.py", line 1138, in __aenter__
    self._resp = await self._coro
  File "/usr/local/lib/python3.9/site-packages/aiohttp/client.py", line 559, in _request
    await resp.start(conn)
  File "/usr/local/lib/python3.9/site-packages/aiohttp/client_reqrep.py", line 898, in start
    message, payload = await protocol.read()  # type: ignore[union-attr]
  File "/usr/local/lib/python3.9/site-packages/aiohttp/streams.py", line 616, in read
    await self._waiter
aiohttp.client_exceptions.ClientOSError: [Errno None] Can not write request body for http://192.168.106.38/v2/devices/1/actions/TurnOff
```